### PR TITLE
fix!: Tidy up about Ord and Eq

### DIFF
--- a/src/bool.ts
+++ b/src/bool.ts
@@ -1,4 +1,5 @@
 import type { Monoid } from "./type-class/monoid.js";
+import { fromEquality } from "./type-class/eq.js";
 
 export const andMonoid: Monoid<boolean> = {
     identity: true,
@@ -8,3 +9,6 @@ export const orMonoid: Monoid<boolean> = {
     identity: false,
     combine: (l, r) => l || r,
 };
+
+export const equality = (lhs: boolean, rhs: boolean): boolean => lhs === rhs;
+export const eq = fromEquality(equality);

--- a/src/bool.ts
+++ b/src/bool.ts
@@ -11,4 +11,4 @@ export const orMonoid: Monoid<boolean> = {
 };
 
 export const equality = (lhs: boolean, rhs: boolean): boolean => lhs === rhs;
-export const eq = fromEquality(equality);
+export const eq = fromEquality(() => equality)();

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -1,10 +1,11 @@
 /* eslint-disable no-console */
 
 import { Eq, eqSymbol } from "./type-class/eq.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Monad1 } from "./type-class/monad.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 
 declare const catNominal: unique symbol;
 export type CatHktKey = typeof catNominal;

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Monad1 } from "./type-class/monad.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 
 declare const catNominal: unique symbol;
 export type CatHktKey = typeof catNominal;

--- a/src/cat.ts
+++ b/src/cat.ts
@@ -1,11 +1,10 @@
 /* eslint-disable no-console */
 
-import { Eq, eqSymbol } from "./type-class/eq.js";
-
 import type { Monad1 } from "./type-class/monad.js";
-import type { Ord } from "./type-class/ord.js";
-import type { PartialEq } from "./type-class/partial-eq.js";
-import type { PartialOrd } from "./type-class/partial-ord.js";
+import { fromProjection as eqFromProjection } from "./type-class/eq.js";
+import { fromProjection as ordFromProjection } from "./type-class/ord.js";
+import { fromProjection as partialEqFromProjection } from "./type-class/partial-eq.js";
+import { fromProjection as partialOrdFromProjection } from "./type-class/partial-ord.js";
 
 declare const catNominal: unique symbol;
 export type CatHktKey = typeof catNominal;
@@ -19,22 +18,12 @@ export const cat = <T>(value: T): Cat<T> => ({
     feed: <U>(fn: (t: T) => U) => cat(fn(value)),
 });
 
-export const partialEq = <T>(equality: PartialEq<T>): PartialEq<Cat<T>> => ({
-    eq: (l, r) => equality.eq(l.value, r.value),
-});
-export const eq = <T>(equality: Eq<T>): Eq<Cat<T>> => ({
-    ...partialEq(equality),
-    [eqSymbol]: true,
-});
-export const partialOrd = <T>(order: PartialOrd<T>): PartialOrd<Cat<T>> => ({
-    ...partialEq(order),
-    partialCmp: (l, r) => order.partialCmp(l.value, r.value),
-});
-export const ord = <T>(order: Ord<T>): Ord<Cat<T>> => ({
-    ...partialOrd(order),
-    cmp: (l, r) => order.cmp(l.value, r.value),
-    [eqSymbol]: true,
-});
+export const get = <T>({ value }: Cat<T>): T => value;
+
+export const partialEq = partialEqFromProjection<CatHktKey>(get);
+export const eq = eqFromProjection<CatHktKey>(get);
+export const partialOrd = partialOrdFromProjection<CatHktKey>(get);
+export const ord = ordFromProjection<CatHktKey>(get);
 
 export const inspect =
     <T>(inspector: (t: T) => void) =>

--- a/src/cofree.ts
+++ b/src/cofree.ts
@@ -9,7 +9,6 @@ import {
     partialEq as lazyPartialEq,
     partialOrd as lazyPartialOrd,
 } from "./lazy.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 import {
     Tuple,
     eq as tupleEq,
@@ -21,7 +20,9 @@ import {
 
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import { compose } from "./func.js";
 
 declare const cofreeNominal: unique symbol;

--- a/src/cofree.ts
+++ b/src/cofree.ts
@@ -1,4 +1,4 @@
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import {
     Lazy,
     force,
@@ -21,6 +21,7 @@ import {
 
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import { compose } from "./func.js";
 
 declare const cofreeNominal: unique symbol;

--- a/src/free.ts
+++ b/src/free.ts
@@ -1,16 +1,16 @@
 import * as Option from "./option.js";
 import * as Result from "./result.js";
 
-import { Eq, eqSymbol } from "./type-class/eq.js";
+import { Eq, fromEquality } from "./type-class/eq.js";
 import { Monad1, Monad2Monoid, kleisli } from "./type-class/monad.js";
-import { greater, less } from "./ordering.js";
+import { Ord, fromCmp } from "./type-class/ord.js";
+import { Ordering, greater, less } from "./ordering.js";
+import { PartialEq, fromPartialEquality } from "./type-class/partial-eq.js";
+import { PartialOrd, fromPartialCmp } from "./type-class/partial-ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
-import type { Ord } from "./type-class/ord.js";
-import type { PartialEq } from "./type-class/partial-eq.js";
-import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 import type { Tuple } from "./tuple.js";
 
@@ -28,115 +28,90 @@ export const isNode = <F, A>(free: Free<F, A>): free is Node<F, A> => free[0] ==
 
 export type Free<F, A> = Pure<A> | Node<F, A>;
 
-export const partialEq = <F, A>(
-    equalityA: PartialEq<A>,
-    equalityFA: <T>(equality: PartialEq<T>) => PartialEq<GetHktA1<F, T>>,
-): PartialEq<Free<F, A>> => {
-    const self: PartialEq<Free<F, A>> = {
-        eq: (l, r) => {
-            if (isPure(l) && isPure(r)) {
-                return equalityA.eq(l[1], r[1]);
-            }
-            if (isNode(l) && isNode(r)) {
-                return equalityFA(self).eq(l[1], r[1]);
-            }
-            return false;
-        },
+export const partialEquality = <F, A>({
+    equalityA,
+    equalityFA,
+}: {
+    equalityA: PartialEq<A>;
+    equalityFA: <T>(equality: PartialEq<T>) => PartialEq<GetHktA1<F, T>>;
+}) => {
+    const self = (l: Free<F, A>, r: Free<F, A>): boolean => {
+        if (isPure(l) && isPure(r)) {
+            return equalityA.eq(l[1], r[1]);
+        }
+        if (isNode(l) && isNode(r)) {
+            return equalityFA(fromPartialEquality(() => self)()).eq(l[1], r[1]);
+        }
+        return false;
     };
     return self;
 };
-export const eq = <F, A>(
-    equalityA: Eq<A>,
-    equalityFA: <T>(equality: Eq<T>) => Eq<GetHktA1<F, T>>,
-): Eq<Free<F, A>> => {
-    const self: Eq<Free<F, A>> = {
-        eq: (l, r) => {
-            if (isPure(l) && isPure(r)) {
-                return equalityA.eq(l[1], r[1]);
-            }
-            if (isNode(l) && isNode(r)) {
-                return equalityFA(self).eq(l[1], r[1]);
-            }
-            return false;
-        },
-        [eqSymbol]: true,
+export const partialEq = fromPartialEquality(partialEquality);
+export const equality = <F, A>({
+    equalityA,
+    equalityFA,
+}: {
+    equalityA: Eq<A>;
+    equalityFA: <T>(equality: Eq<T>) => Eq<GetHktA1<F, T>>;
+}) => {
+    const self = (l: Free<F, A>, r: Free<F, A>): boolean => {
+        if (isPure(l) && isPure(r)) {
+            return equalityA.eq(l[1], r[1]);
+        }
+        if (isNode(l) && isNode(r)) {
+            return equalityFA(fromEquality(() => self)()).eq(l[1], r[1]);
+        }
+        return false;
     };
     return self;
 };
-export const partialOrd = <F, A>(
-    orderA: PartialOrd<A>,
-    orderFA: <T>(order: PartialOrd<T>) => PartialOrd<GetHktA1<F, T>>,
-): PartialOrd<Free<F, A>> => {
-    const self: PartialOrd<Free<F, A>> = {
-        eq: (l, r) => {
-            if (isPure(l) && isPure(r)) {
-                return orderA.eq(l[1], r[1]);
-            }
-            if (isNode(l) && isNode(r)) {
-                return orderFA(self).eq(l[1], r[1]);
-            }
-            return false;
-        },
-        partialCmp: (l, r) => {
-            // considered that Pure is lesser than Node
-            if (isPure(l)) {
-                if (isPure(r)) {
-                    return orderA.partialCmp(l[1], r[1]);
-                }
-                return Option.some(less);
-            }
+export const eq = fromEquality(equality);
+export const partialCmp = <F, A>({
+    orderA,
+    orderFA,
+}: {
+    orderA: PartialOrd<A>;
+    orderFA: <T>(order: PartialOrd<T>) => PartialOrd<GetHktA1<F, T>>;
+}) => {
+    const self = (l: Free<F, A>, r: Free<F, A>): Option.Option<Ordering> => {
+        // considered that Pure is lesser than Node
+        if (isPure(l)) {
             if (isPure(r)) {
-                return Option.some(greater);
+                return orderA.partialCmp(l[1], r[1]);
             }
-            return orderFA(self).partialCmp(l[1], r[1]);
-        },
+            return Option.some(less);
+        }
+        if (isPure(r)) {
+            return Option.some(greater);
+        }
+        return orderFA(fromPartialCmp(() => self)()).partialCmp(l[1], r[1]);
     };
     return self;
 };
-export const ord = <F, A>(
-    orderA: Ord<A>,
-    orderFA: <T>(order: Ord<T>) => Ord<GetHktA1<F, T>>,
-): Ord<Free<F, A>> => {
-    const self: Ord<Free<F, A>> = {
-        eq: (l, r) => {
-            if (isPure(l) && isPure(r)) {
-                return orderA.eq(l[1], r[1]);
-            }
-            if (isNode(l) && isNode(r)) {
-                return orderFA(self).eq(l[1], r[1]);
-            }
-            return false;
-        },
-        [eqSymbol]: true,
-        partialCmp: (l, r) => {
-            // considered that Pure is lesser than Node
-            if (isPure(l)) {
-                if (isPure(r)) {
-                    return orderA.partialCmp(l[1], r[1]);
-                }
-                return Option.some(less);
-            }
+export const partialOrd = fromPartialCmp(partialCmp);
+export const cmp = <F, A>({
+    orderA,
+    orderFA,
+}: {
+    orderA: Ord<A>;
+    orderFA: <T>(order: Ord<T>) => Ord<GetHktA1<F, T>>;
+}) => {
+    const self = (l: Free<F, A>, r: Free<F, A>): Ordering => {
+        // considered that Pure is lesser than Node
+        if (isPure(l)) {
             if (isPure(r)) {
-                return Option.some(greater);
+                return orderA.cmp(l[1], r[1]);
             }
-            return orderFA(self).partialCmp(l[1], r[1]);
-        },
-        cmp: (l, r) => {
-            // considered that Pure is lesser than Node
-            if (isPure(l)) {
-                if (isPure(r)) {
-                    return orderA.cmp(l[1], r[1]);
-                }
-                return less;
-            }
-            if (isPure(r)) {
-                return greater;
-            }
-            return orderFA(self).cmp(l[1], r[1]);
-        },
+            return less;
+        }
+        if (isPure(r)) {
+            return greater;
+        }
+        return orderFA(fromCmp(() => self)()).cmp(l[1], r[1]);
     };
     return self;
 };
+export const ord = fromCmp(cmp);
 
 export const retract =
     <F>(monad: Monad1<F>) =>

--- a/src/free.ts
+++ b/src/free.ts
@@ -3,13 +3,14 @@ import * as Result from "./result.js";
 
 import { Eq, eqSymbol } from "./type-class/eq.js";
 import { Monad1, Monad2Monoid, kleisli } from "./type-class/monad.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 import { greater, less } from "./ordering.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 import type { Tuple } from "./tuple.js";
 

--- a/src/free.ts
+++ b/src/free.ts
@@ -1,7 +1,7 @@
 import * as Option from "./option.js";
 import * as Result from "./result.js";
 
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import { Monad1, Monad2Monoid, kleisli } from "./type-class/monad.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 import { greater, less } from "./ordering.js";
@@ -9,6 +9,7 @@ import { greater, less } from "./ordering.js";
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 import type { Tuple } from "./tuple.js";
 

--- a/src/frozen.ts
+++ b/src/frozen.ts
@@ -1,3 +1,8 @@
+import { Eq, PartialEq, fromEquality, fromPartialEquality } from "./type-class/eq.js";
+import { Option, andThen, none, some } from "./option.js";
+import { Ord, PartialOrd, fromCmp, fromPartialCmp } from "./type-class/ord.js";
+import { Ordering, isEq, and as then } from "./ordering.js";
+
 import type { Monad1 } from "./type-class/monad.js";
 import { id } from "./func.js";
 
@@ -12,6 +17,51 @@ export type Frozen<T> = T & {
         ? Frozen<T[K]>
         : T[K];
 };
+
+export const equality =
+    <S>(equalityDict: { readonly [K in keyof S]: PartialEq<S[K]> }) =>
+    (l: Readonly<S>, r: Readonly<S>): boolean =>
+        Object.keys(equalityDict).every((key) => {
+            if (Object.hasOwn(equalityDict, key)) {
+                const castKey = key as keyof S;
+                return equalityDict[castKey].eq(l[castKey], r[castKey]);
+            }
+            return true;
+        });
+export const partialEq = <S>(equalityDict: { readonly [K in keyof S]: PartialEq<S[K]> }) =>
+    fromPartialEquality(equality(equalityDict));
+export const eq = <S>(equalityDict: { readonly [K in keyof S]: Eq<S[K]> }) =>
+    fromEquality(equality(equalityDict));
+export const partialCmp =
+    <S>(orderDict: { readonly [K in keyof S]: PartialOrd<S[K]> }) =>
+    (l: Readonly<S>, r: Readonly<S>): Option<Ordering> =>
+        Object.keys(orderDict)
+            .map((key) => {
+                if (Object.hasOwn(orderDict, key)) {
+                    const castKey = key as keyof S;
+                    return orderDict[castKey].partialCmp(l[castKey], r[castKey]);
+                }
+                return none();
+            })
+            .reduce((prev, curr) =>
+                andThen((previous: Ordering) => (isEq(previous) ? curr : some(previous)))(prev),
+            );
+export const partialOrd = <S>(orderDict: { readonly [K in keyof S]: PartialOrd<S[K]> }) =>
+    fromPartialCmp(partialCmp(orderDict));
+export const cmp =
+    <S>(orderDict: { readonly [K in keyof S]: Ord<S[K]> }) =>
+    (l: Readonly<S>, r: Readonly<S>): Ordering =>
+        Object.keys(orderDict)
+            .map((key) => {
+                if (Object.hasOwn(orderDict, key)) {
+                    const castKey = key as keyof S;
+                    return orderDict[castKey].cmp(l[castKey], r[castKey]);
+                }
+                throw new Error("`orderDict` must have comparator by own key");
+            })
+            .reduce((prev, curr) => then(curr)(prev));
+export const ord = <S>(orderDict: { readonly [K in keyof S]: Ord<S[K]> }) =>
+    fromCmp(cmp(orderDict));
 
 export const freeze = <T>(x: T): Frozen<T> => x as Frozen<T>;
 

--- a/src/frozen.ts
+++ b/src/frozen.ts
@@ -1,7 +1,8 @@
-import { Eq, PartialEq, fromEquality, fromPartialEquality } from "./type-class/eq.js";
+import { Eq, fromEquality } from "./type-class/eq.js";
 import { Option, andThen, none, some } from "./option.js";
 import { Ord, PartialOrd, fromCmp, fromPartialCmp } from "./type-class/ord.js";
 import { Ordering, isEq, and as then } from "./ordering.js";
+import { PartialEq, fromPartialEquality } from "./type-class/partial-eq.js";
 
 import type { Monad1 } from "./type-class/monad.js";
 import { id } from "./func.js";

--- a/src/frozen.ts
+++ b/src/frozen.ts
@@ -1,8 +1,9 @@
 import { Eq, fromEquality } from "./type-class/eq.js";
 import { Option, andThen, none, some } from "./option.js";
-import { Ord, PartialOrd, fromCmp, fromPartialCmp } from "./type-class/ord.js";
+import { Ord, fromCmp } from "./type-class/ord.js";
 import { Ordering, isEq, and as then } from "./ordering.js";
 import { PartialEq, fromPartialEquality } from "./type-class/partial-eq.js";
+import { PartialOrd, fromPartialCmp } from "./type-class/partial-ord.js";
 
 import type { Monad1 } from "./type-class/monad.js";
 import { id } from "./func.js";

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -1,13 +1,12 @@
-import { Eq, eqSymbol } from "./type-class/eq.js";
-
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
-import type { Ord } from "./type-class/ord.js";
-import type { PartialEq } from "./type-class/partial-eq.js";
-import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
+import { fromProjection as eqFromProjection } from "./type-class/eq.js";
+import { fromProjection as ordFromProjection } from "./type-class/ord.js";
+import { fromProjection as partialEqFromProjection } from "./type-class/partial-eq.js";
+import { fromProjection as partialOrdFromProjection } from "./type-class/partial-ord.js";
 
 const lazyNominal = Symbol("Lazy");
 export type LazyHktKey = typeof lazyNominal;
@@ -19,22 +18,10 @@ export const defer = <L>(deferred: () => L): Lazy<L> => ({ [lazyNominal]: deferr
 
 export const force = <L>(lazy: Lazy<L>): L => lazy[lazyNominal]();
 
-export const partialEq = <T>(equality: PartialEq<T>): PartialEq<Lazy<T>> => ({
-    eq: (a, b) => equality.eq(force(a), force(b)),
-});
-export const eq = <T>(equality: Eq<T>): Eq<Lazy<T>> => ({
-    ...partialEq(equality),
-    [eqSymbol]: true,
-});
-export const partialOrd = <T>(order: PartialOrd<T>): PartialOrd<Lazy<T>> => ({
-    ...partialEq(order),
-    partialCmp: (l, r) => order.partialCmp(force(l), force(r)),
-});
-export const ord = <T>(order: Ord<T>): Ord<Lazy<T>> => ({
-    ...partialOrd(order),
-    cmp: (l, r) => order.cmp(force(l), force(r)),
-    [eqSymbol]: true,
-});
+export const partialEq = partialEqFromProjection<LazyHktKey>(force);
+export const eq = eqFromProjection<LazyHktKey>(force);
+export const partialOrd = partialOrdFromProjection<LazyHktKey>(force);
+export const ord = ordFromProjection<LazyHktKey>(force);
 
 export const pure = <A>(a: A): Lazy<A> => defer(() => a);
 export const map =

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -1,11 +1,12 @@
 import { Eq, eqSymbol } from "./type-class/eq.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 
 const lazyNominal = Symbol("Lazy");

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -1,10 +1,11 @@
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 
 const lazyNominal = Symbol("Lazy");

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -53,7 +53,7 @@ import {
 } from "../src/list.js";
 import { expect, test } from "vitest";
 
-import { strict } from "../src/type-class/eq.js";
+import { strict } from "../src/type-class/partial-eq.js";
 
 test("isNull", () => {
     expect(isNull(empty())).toEqual(true);

--- a/src/list.ts
+++ b/src/list.ts
@@ -2,13 +2,14 @@ import * as Applicative from "./type-class/applicative.js";
 import * as Cat from "./cat.js";
 import * as Option from "./option.js";
 
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 import type { Tuple } from "./tuple.js";
 import { andThen } from "./ordering.js";

--- a/src/list.ts
+++ b/src/list.ts
@@ -3,13 +3,14 @@ import * as Cat from "./cat.js";
 import * as Option from "./option.js";
 
 import { Eq, eqSymbol } from "./type-class/eq.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Functor1 } from "./type-class/functor.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 import type { Tuple } from "./tuple.js";
 import { andThen } from "./ordering.js";

--- a/src/number.ts
+++ b/src/number.ts
@@ -15,4 +15,4 @@ export const partialCmp = (lhs: number, rhs: number): Option<Ordering> => {
     }
     return some(greater);
 };
-export const partialOrd = fromPartialCmp(partialCmp);
+export const partialOrd = fromPartialCmp(() => partialCmp)();

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,7 +1,7 @@
 import { Option, none, some } from "./option.js";
 import { Ordering, equal, greater, less } from "./ordering.js";
 
-import { fromPartialCmp } from "./type-class/ord.js";
+import { fromPartialCmp } from "./type-class/partial-ord.js";
 
 export const partialCmp = (lhs: number, rhs: number): Option<Ordering> => {
     if (Number.isNaN(lhs) || Number.isNaN(rhs)) {

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,0 +1,18 @@
+import { Option, none, some } from "./option.js";
+import { Ordering, equal, greater, less } from "./ordering.js";
+
+import { fromPartialCmp } from "./type-class/ord.js";
+
+export const partialCmp = (lhs: number, rhs: number): Option<Ordering> => {
+    if (Number.isNaN(lhs) || Number.isNaN(rhs)) {
+        return none();
+    }
+    if (lhs == rhs) {
+        return some(equal);
+    }
+    if (lhs < rhs) {
+        return some(less);
+    }
+    return some(greater);
+};
+export const partialOrd = fromPartialCmp(partialCmp);

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,5 +1,4 @@
 import { Eq, eqSymbol } from "./type-class/eq.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 import { Result, err, isOk, ok } from "./result.js";
 import { equal, greater, less } from "./ordering.js";
 
@@ -7,7 +6,9 @@ import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 
 const someSymbol = Symbol("OptionSome");

--- a/src/option.ts
+++ b/src/option.ts
@@ -85,7 +85,8 @@ export const cmp =
         }
         return order.cmp(l[1], r[1]);
     };
-export const ord = fromCmp(cmp);
+// This argument wrapper is needed for avoid cyclic-import problem.
+export const ord = <T>(order: Ord<T, T>) => fromCmp(cmp)(order);
 
 export const flatten = <T>(opt: Option<Option<T>>): Option<T> => {
     if (isSome(opt)) {

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,4 +1,4 @@
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 import { Result, err, isOk, ok } from "./result.js";
 import { equal, greater, less } from "./ordering.js";
@@ -7,6 +7,7 @@ import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 
 const someSymbol = Symbol("OptionSome");

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,14 +1,14 @@
-import { Eq, eqSymbol } from "./type-class/eq.js";
+import { Eq, fromEquality } from "./type-class/eq.js";
+import { Ord, fromCmp } from "./type-class/ord.js";
+import { Ordering, equal, greater, less } from "./ordering.js";
+import { PartialEq, fromPartialEquality } from "./type-class/partial-eq.js";
+import { PartialOrd, fromPartialCmp } from "./type-class/partial-ord.js";
 import { Result, err, isOk, ok } from "./result.js";
-import { equal, greater, less } from "./ordering.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad1 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
-import type { Ord } from "./type-class/ord.js";
-import type { PartialEq } from "./type-class/partial-eq.js";
-import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable1 } from "./type-class/traversable.js";
 
 const someSymbol = Symbol("OptionSome");
@@ -42,18 +42,21 @@ export const toArray = <T>(opt: Option<T>): T[] => {
     return arr as T[];
 };
 
-export const partialEq = <T>(equality: PartialEq<T>): PartialEq<Option<T>> => ({
-    eq: (optA: Option<T>, optB: Option<T>): boolean =>
-        (isSome(optA) && isSome(optB) && equality.eq(optA[1], optB[1])) ||
-        (isNone(optA) && isNone(optB)),
-});
-export const eq = <T>(equality: Eq<T>): Eq<Option<T>> => ({
-    ...partialEq(equality),
-    [eqSymbol]: true,
-});
-export const partialOrd = <T>(order: PartialOrd<T>): PartialOrd<Option<T>> => ({
-    ...partialEq(order),
-    partialCmp: (l, r) => {
+export const partialEquality =
+    <T>(equalityT: PartialEq<T>) =>
+    (optA: Option<T>, optB: Option<T>): boolean =>
+        (isSome(optA) && isSome(optB) && equalityT.eq(optA[1], optB[1])) ||
+        (isNone(optA) && isNone(optB));
+export const partialEq = fromPartialEquality(partialEquality);
+export const equality =
+    <T>(equalityT: Eq<T>) =>
+    (optA: Option<T>, optB: Option<T>): boolean =>
+        (isSome(optA) && isSome(optB) && equalityT.eq(optA[1], optB[1])) ||
+        (isNone(optA) && isNone(optB));
+export const eq = fromEquality(equality);
+export const partialCmp =
+    <T>(order: PartialOrd<T>) =>
+    (l: Option<T>, r: Option<T>): Option<Ordering> => {
         // considered that None is lesser than Some
         if (isNone(l)) {
             if (isNone(r)) {
@@ -65,11 +68,11 @@ export const partialOrd = <T>(order: PartialOrd<T>): PartialOrd<Option<T>> => ({
             return some(greater);
         }
         return order.partialCmp(l[1], r[1]);
-    },
-});
-export const ord = <T>(order: Ord<T>): Ord<Option<T>> => ({
-    ...partialOrd(order),
-    cmp: (l, r) => {
+    };
+export const partialOrd = fromPartialCmp(partialCmp);
+export const cmp =
+    <T>(order: Ord<T>) =>
+    (l: Option<T>, r: Option<T>): Ordering => {
         // considered that None is lesser than Some
         if (isNone(l)) {
             if (isNone(r)) {
@@ -81,9 +84,8 @@ export const ord = <T>(order: Ord<T>): Ord<Option<T>> => ({
             return greater;
         }
         return order.cmp(l[1], r[1]);
-    },
-    [eqSymbol]: true,
-});
+    };
+export const ord = fromCmp(cmp);
 
 export const flatten = <T>(opt: Option<Option<T>>): Option<T> => {
     if (isSome(opt)) {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,14 +1,14 @@
-import { Eq, eqSymbol } from "./type-class/eq.js";
+import { Eq, fromEquality } from "./type-class/eq.js";
 import { Option, isSome, none, toArray as optionToArray, some } from "./option.js";
-import { greater, less } from "./ordering.js";
+import { Ord, fromCmp } from "./type-class/ord.js";
+import { Ordering, greater, less } from "./ordering.js";
+import { PartialEq, fromPartialEquality } from "./type-class/partial-eq.js";
+import { PartialOrd, fromPartialCmp } from "./type-class/partial-ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad2 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
-import type { Ord } from "./type-class/ord.js";
-import type { PartialEq } from "./type-class/partial-eq.js";
-import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable2 } from "./type-class/traversable.js";
 
 const okSymbol = Symbol("ResultOk");
@@ -27,11 +27,9 @@ export const err = <E, T>(e: E): Result<E, T> => [errSymbol, e];
 export const isOk = <E, T>(res: Result<E, T>): res is Ok<T> => res[0] === okSymbol;
 export const isErr = <E, T>(res: Result<E, T>): res is Err<E> => res[0] === errSymbol;
 
-export const partialEq = <E, T>(
-    equalityE: PartialEq<E>,
-    equalityT: PartialEq<T>,
-): PartialEq<Result<E, T>> => ({
-    eq: (l, r) => {
+export const partialEquality =
+    <E, T>({ equalityE, equalityT }: { equalityE: PartialEq<E>; equalityT: PartialEq<T> }) =>
+    (l: Result<E, T>, r: Result<E, T>): boolean => {
         if (isErr(l) && isErr(r)) {
             return equalityE.eq(l[1], r[1]);
         }
@@ -39,18 +37,14 @@ export const partialEq = <E, T>(
             return equalityT.eq(l[1], r[1]);
         }
         return false;
-    },
-});
-export const eq = <E, T>(equalityE: Eq<E>, equalityT: Eq<T>): Eq<Result<E, T>> => ({
-    ...partialEq(equalityE, equalityT),
-    [eqSymbol]: true,
-});
-export const partialOrd = <E, T>(
-    orderE: PartialOrd<E>,
-    orderT: PartialOrd<T>,
-): PartialOrd<Result<E, T>> => ({
-    ...partialEq(orderE, orderT),
-    partialCmp: (l, r) => {
+    };
+export const partialEq = fromPartialEquality(partialEquality);
+export const equality = <E, T>(equalities: { equalityE: Eq<E>; equalityT: Eq<T> }) =>
+    partialEquality(equalities);
+export const eq = fromEquality(equality);
+export const partialCmp =
+    <E, T>({ orderE, orderT }: { orderE: PartialOrd<E>; orderT: PartialOrd<T> }) =>
+    (l: Result<E, T>, r: Result<E, T>): Option<Ordering> => {
         // considered that Ok is lesser than Err
         if (isOk(l)) {
             if (isOk(r)) {
@@ -62,11 +56,11 @@ export const partialOrd = <E, T>(
             return some(greater);
         }
         return orderE.partialCmp(l[1], r[1]);
-    },
-});
-export const ord = <E, T>(orderE: Ord<E>, orderT: Ord<T>): Ord<Result<E, T>> => ({
-    ...partialOrd(orderE, orderT),
-    cmp: (l, r) => {
+    };
+export const partialOrd = fromPartialCmp(partialCmp);
+export const cmp =
+    <E, T>({ orderE, orderT }: { orderE: Ord<E>; orderT: Ord<T> }) =>
+    (l: Result<E, T>, r: Result<E, T>): Ordering => {
         // considered that Ok is lesser than Err
         if (isOk(l)) {
             if (isOk(r)) {
@@ -78,9 +72,8 @@ export const ord = <E, T>(orderE: Ord<E>, orderT: Ord<T>): Ord<Result<E, T>> => 
             return greater;
         }
         return orderE.cmp(l[1], r[1]);
-    },
-    [eqSymbol]: true,
-});
+    };
+export const ord = fromCmp(cmp);
 
 export const either =
     <E, R>(g: (e: E) => R) =>

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,4 @@
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import { Option, isSome, none, toArray as optionToArray, some } from "./option.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 import { greater, less } from "./ordering.js";
@@ -7,6 +7,7 @@ import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad2 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import type { Traversable2 } from "./type-class/traversable.js";
 
 const okSymbol = Symbol("ResultOk");

--- a/src/result.ts
+++ b/src/result.ts
@@ -73,7 +73,8 @@ export const cmp =
         }
         return orderE.cmp(l[1], r[1]);
     };
-export const ord = fromCmp(cmp);
+// This argument wrapper is needed for avoid cyclic-import problem.
+export const ord = <E, T>(x: { orderE: Ord<E, E>; orderT: Ord<T, T> }) => fromCmp(cmp)(x);
 
 export const either =
     <E, R>(g: (e: E) => R) =>

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,13 +1,14 @@
 import { Eq, eqSymbol } from "./type-class/eq.js";
 import { Option, isSome, none, toArray as optionToArray, some } from "./option.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 import { greater, less } from "./ordering.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monad2 } from "./type-class/monad.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { Traversable2 } from "./type-class/traversable.js";
 
 const okSymbol = Symbol("ResultOk");

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,7 @@
 import type { Monad1, Monad2 } from "./type-class/monad.js";
 
 import type { Functor2 } from "./type-class/functor.js";
-import type { GetHktA1 } from "src/hkt.js";
+import type { GetHktA1 } from "./hkt.js";
 import type { IdentityHktKey } from "./identity.js";
 import type { Tuple } from "./tuple.js";
 

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,0 +1,13 @@
+import { Ord, fromCmp } from "./type-class/ord.js";
+import { Ordering, equal, greater, less } from "./ordering.js";
+
+export const cmp = (lhs: string, rhs: string): Ordering => {
+    if (lhs === rhs) {
+        return equal;
+    }
+    if (lhs < rhs) {
+        return less;
+    }
+    return greater;
+};
+export const ord: Ord<string> = fromCmp(cmp);

--- a/src/string.ts
+++ b/src/string.ts
@@ -10,4 +10,4 @@ export const cmp = (lhs: string, rhs: string): Ordering => {
     }
     return greater;
 };
-export const ord: Ord<string> = fromCmp(cmp);
+export const ord: Ord<string> = fromCmp(() => cmp)();

--- a/src/tuple-n.ts
+++ b/src/tuple-n.ts
@@ -1,0 +1,42 @@
+import { Option, isNone, none, some } from "./option.js";
+import { type Ordering, equal, and } from "./ordering.js";
+import { fromCmp, fromPartialCmp, Ord, PartialOrd } from "./type-class/ord.js";
+
+export type TupleN<T extends unknown[]> = {
+    readonly [K in keyof T]: PartialOrd<T[K]>;
+};
+
+export const partialCmp =
+    <T extends unknown[]>(orderDict: {
+        readonly [K in keyof T]: PartialOrd<T[K]>;
+    }) =>
+    (lhs: TupleN<T>, rhs: TupleN<T>): Option<Ordering> => {
+        const len = Math.min(lhs.length, rhs.length);
+        let result: Ordering = equal;
+        for (let i = 0; i < len; i += 1) {
+            const order = orderDict[i].partialCmp(lhs[i], rhs[i]);
+            if (isNone(order)) {
+                return none();
+            }
+            result = and(order[1])(result);
+        }
+        return some(result);
+    };
+export const partialOrd = <T extends unknown[]>(orderDict: {
+    readonly [K in keyof T]: PartialOrd<T[K]>;
+}) => fromPartialCmp(partialCmp(orderDict));
+export const cmp =
+    <T extends unknown[]>(orderDict: {
+        readonly [K in keyof T]: Ord<T[K]>;
+    }) =>
+    (lhs: TupleN<T>, rhs: TupleN<T>): Ordering => {
+        const len = Math.min(lhs.length, rhs.length);
+        let result: Ordering = equal;
+        for (let i = 0; i < len; i += 1) {
+            result = and(orderDict[i].cmp(lhs[i], rhs[i]))(result);
+        }
+        return result;
+    };
+export const ord = <T extends unknown[]>(orderDict: {
+    readonly [K in keyof T]: Ord<T[K]>;
+}) => fromCmp(cmp(orderDict));

--- a/src/tuple-n.ts
+++ b/src/tuple-n.ts
@@ -1,7 +1,7 @@
 import { Option, isNone, none, some } from "./option.js";
-import { type Ordering, equal, and } from "./ordering.js";
-import { fromCmp, Ord } from "./type-class/ord.js";
-import { fromPartialCmp, PartialOrd } from "./type-class/partial-ord.js";
+import { Ord, fromCmp } from "./type-class/ord.js";
+import { Ordering, and, equal } from "./ordering.js";
+import { PartialOrd, fromPartialCmp } from "./type-class/partial-ord.js";
 
 export type TupleN<T extends unknown[]> = {
     readonly [K in keyof T]: PartialOrd<T[K]>;

--- a/src/tuple-n.ts
+++ b/src/tuple-n.ts
@@ -1,6 +1,7 @@
 import { Option, isNone, none, some } from "./option.js";
 import { type Ordering, equal, and } from "./ordering.js";
-import { fromCmp, fromPartialCmp, Ord, PartialOrd } from "./type-class/ord.js";
+import { fromCmp, Ord } from "./type-class/ord.js";
+import { fromPartialCmp, PartialOrd } from "./type-class/partial-ord.js";
 
 export type TupleN<T extends unknown[]> = {
     readonly [K in keyof T]: PartialOrd<T[K]>;

--- a/src/tuple-n.ts
+++ b/src/tuple-n.ts
@@ -23,9 +23,7 @@ export const partialCmp =
         }
         return some(result);
     };
-export const partialOrd = <T extends unknown[]>(orderDict: {
-    readonly [K in keyof T]: PartialOrd<T[K]>;
-}) => fromPartialCmp(partialCmp(orderDict));
+export const partialOrd = fromPartialCmp(partialCmp);
 export const cmp =
     <T extends unknown[]>(orderDict: {
         readonly [K in keyof T]: Ord<T[K]>;
@@ -38,6 +36,4 @@ export const cmp =
         }
         return result;
     };
-export const ord = <T extends unknown[]>(orderDict: {
-    readonly [K in keyof T]: Ord<T[K]>;
-}) => fromCmp(cmp(orderDict));
+export const ord = fromCmp(cmp);

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -1,10 +1,11 @@
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import { Lazy, force, defer as lazyDefer } from "./lazy.js";
 import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import type { SemiGroup } from "./type-class/semi-group.js";
 import { andThen } from "./option.js";
 import { andThen as thenWith } from "./ordering.js";

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -1,41 +1,38 @@
-import { Eq, eqSymbol } from "./type-class/eq.js";
+import { Eq, fromEquality } from "./type-class/eq.js";
 import { Lazy, force, defer as lazyDefer } from "./lazy.js";
+import { Option, andThen } from "./option.js";
+import { Ord, fromCmp } from "./type-class/ord.js";
+import { Ordering, andThen as thenWith } from "./ordering.js";
+import { PartialEq, fromPartialEquality } from "./type-class/partial-eq.js";
+import { PartialOrd, fromPartialCmp } from "./type-class/partial-ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monoid } from "./type-class/monoid.js";
-import type { Ord } from "./type-class/ord.js";
-import type { PartialEq } from "./type-class/partial-eq.js";
-import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { SemiGroup } from "./type-class/semi-group.js";
-import { andThen } from "./option.js";
-import { andThen as thenWith } from "./ordering.js";
 
 export type Tuple<A, B> = readonly [A, B];
 
-export const partialEq = <A, B>(
-    equalityA: PartialEq<A>,
-    equalityB: PartialEq<B>,
-): PartialEq<Tuple<A, B>> => ({
-    eq: (l, r) => equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]),
-});
-export const eq = <A, B>(equalityA: Eq<A>, equalityB: Eq<B>): Eq<Tuple<A, B>> => ({
-    ...partialEq(equalityA, equalityB),
-    [eqSymbol]: true,
-});
-export const partialOrd = <A, B>(
-    ordA: PartialOrd<A>,
-    ordB: PartialOrd<B>,
-): PartialOrd<Tuple<A, B>> => ({
-    ...partialEq(ordA, ordB),
-    partialCmp: ([a1, b1], [a2, b2]) =>
-        andThen(() => ordB.partialCmp(b1, b2))(ordA.partialCmp(a1, a2)),
-});
-export const ord = <A, B>(ordA: Ord<A>, ordB: Ord<B>): Ord<Tuple<A, B>> => ({
-    ...partialOrd(ordA, ordB),
-    cmp: ([a1, b1], [a2, b2]) => thenWith(() => ordB.cmp(b1, b2))(ordA.cmp(a1, a2)),
-    [eqSymbol]: true,
-});
+export const partialEquality =
+    <A, B>({ equalityA, equalityB }: { equalityA: PartialEq<A>; equalityB: PartialEq<B> }) =>
+    (l: Tuple<A, B>, r: Tuple<A, B>): boolean =>
+        equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]);
+export const partialEq = fromPartialEquality(partialEquality);
+export const equality =
+    <A, B>({ equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<B> }) =>
+    (l: Tuple<A, B>, r: Tuple<A, B>): boolean =>
+        equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]);
+export const eq = fromEquality(equality);
+export const partialCmp =
+    <A, B>({ ordA, ordB }: { ordA: PartialOrd<A>; ordB: PartialOrd<B> }) =>
+    ([a1, b1]: Tuple<A, B>, [a2, b2]: Tuple<A, B>): Option<Ordering> =>
+        andThen(() => ordB.partialCmp(b1, b2))(ordA.partialCmp(a1, a2));
+export const partialOrd = fromPartialCmp(partialCmp);
+export const cmp =
+    <A, B>({ ordA, ordB }: { ordA: Ord<A>; ordB: Ord<B> }) =>
+    ([a1, b1]: Tuple<A, B>, [a2, b2]: Tuple<A, B>) =>
+        thenWith(() => ordB.cmp(b1, b2))(ordA.cmp(a1, a2));
+export const ord = fromCmp(cmp);
 
 export const make =
     <A>(a: A) =>

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -1,11 +1,12 @@
 import { Eq, eqSymbol } from "./type-class/eq.js";
 import { Lazy, force, defer as lazyDefer } from "./lazy.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Applicative1 } from "./type-class/applicative.js";
 import type { GetHktA1 } from "./hkt.js";
 import type { Monoid } from "./type-class/monoid.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import type { SemiGroup } from "./type-class/semi-group.js";
 import { andThen } from "./option.js";
 import { andThen as thenWith } from "./ordering.js";

--- a/src/type-class/eq.ts
+++ b/src/type-class/eq.ts
@@ -1,4 +1,4 @@
-import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "../hkt.js";
 
 import type { PartialEq } from "./partial-eq.js";
 

--- a/src/type-class/eq.ts
+++ b/src/type-class/eq.ts
@@ -1,43 +1,4 @@
-import type { Contravariant } from "./variance.js";
-import type { Monoid } from "./monoid.js";
-
-/**
- * All instances of `PartialEq` must satisfy the following conditions:
- * - Symmetric: `PartialEq<A, B>` always equals to `PartialEq<B, A>`.
- * - Transitive: `PartialEq<A, B>` and `PartialEq<B, C>` always implies `PartialEq<A, C>`.
- */
-export interface PartialEq<Lhs, Rhs = Lhs> {
-    readonly eq: (l: Lhs, r: Rhs) => boolean;
-}
-
-declare const partialEqNominal: unique symbol;
-export type PartialEqHktKey = typeof partialEqNominal;
-declare module "../hkt.js" {
-    interface HktDictA1<A1> {
-        [partialEqNominal]: PartialEq<A1>;
-    }
-}
-
-export const contravariant: Contravariant<PartialEqHktKey> = {
-    contraMap:
-        <T1, T2>(f: (arg: T1) => T2) =>
-        (p: PartialEq<T2>): PartialEq<T1> => ({ eq: (l, r) => p.eq(f(l), f(r)) }),
-};
-
-export const fromPartialEquality = <Lhs, Rhs>(
-    partialEquality: (l: Lhs, r: Rhs) => boolean,
-): PartialEq<Lhs, Rhs> => ({
-    eq: partialEquality,
-});
-
-export const strict = <T>() => fromPartialEquality<T, T>((l, r) => l === r);
-
-export const identity = fromPartialEquality(() => true);
-
-export const monoid = <Lhs, Rhs>(): Monoid<PartialEq<Lhs, Rhs>> => ({
-    combine: (x, y) => ({ eq: (l, r) => x.eq(l, r) && y.eq(l, r) }),
-    identity,
-});
+import type { PartialEq } from "./partial-eq.js";
 
 export const eqSymbol = Symbol("ImplEq");
 

--- a/src/type-class/eq.ts
+++ b/src/type-class/eq.ts
@@ -20,10 +20,12 @@ export interface Eq<Lhs, Rhs = Lhs> extends PartialEq<Lhs, Rhs> {
     readonly [eqSymbol]: true;
 }
 
-export const fromEquality = <Lhs, Rhs>(equality: (l: Lhs, r: Rhs) => boolean): Eq<Lhs, Rhs> => ({
-    eq: equality,
-    [eqSymbol]: true,
-});
+export const fromEquality =
+    <Lhs, Rhs, X = void>(equality: (x: X) => (l: Lhs, r: Rhs) => boolean) =>
+    (x: X): Eq<Lhs, Rhs> => ({
+        eq: equality(x),
+        [eqSymbol]: true,
+    });
 
 export function fromProjection<F>(
     projection: <X>(structure: GetHktA1<F, X>) => X,

--- a/src/type-class/eq.ts
+++ b/src/type-class/eq.ts
@@ -1,3 +1,5 @@
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
+
 import type { PartialEq } from "./partial-eq.js";
 
 export const eqSymbol = Symbol("ImplEq");
@@ -22,3 +24,24 @@ export const fromEquality = <Lhs, Rhs>(equality: (l: Lhs, r: Rhs) => boolean): E
     eq: equality,
     [eqSymbol]: true,
 });
+
+export function fromProjection<F>(
+    projection: <X>(structure: GetHktA1<F, X>) => X,
+): <T>(equality: Eq<T>) => Eq<GetHktA1<F, T>>;
+export function fromProjection<F, A>(
+    projection: <X>(structure: GetHktA2<F, A, X>) => X,
+): <T>(equality: Eq<T>) => Eq<GetHktA2<F, A, T>>;
+export function fromProjection<F, B, A>(
+    projection: <X>(structure: GetHktA3<F, B, A, X>) => X,
+): <T>(equality: Eq<T>) => Eq<GetHktA3<F, B, A, T>>;
+export function fromProjection<F, C, B, A>(
+    projection: <X>(structure: GetHktA4<F, C, B, A, X>) => X,
+): <T>(equality: Eq<T>) => Eq<GetHktA4<F, C, B, A, T>>;
+export function fromProjection<F extends symbol>(
+    projection: <X>(structure: Hkt<F, X>) => X,
+): <T>(equality: Eq<T>) => Eq<Hkt<F, T>> {
+    return (equality) => ({
+        eq: (l, r) => equality.eq(projection(l), projection(r)),
+        [eqSymbol]: true,
+    });
+}

--- a/src/type-class/foldable.ts
+++ b/src/type-class/foldable.ts
@@ -5,7 +5,7 @@ import { Option, isNone, none, some, unwrapOrElse } from "../option.js";
 import { andMonoid, orMonoid } from "../bool.js";
 import { compose, oneShot } from "../func.js";
 
-import type { PartialEq } from "./eq.js";
+import type { PartialEq } from "./partial-eq.js";
 
 export interface Foldable1<T> {
     readonly foldR: <A, B>(

--- a/src/type-class/ord.ts
+++ b/src/type-class/ord.ts
@@ -1,9 +1,10 @@
-import { Eq, PartialEq, eqSymbol } from "./eq.js";
+import { Eq, eqSymbol } from "./eq.js";
 import { Option, flatMap, map, mapOr, some } from "../option.js";
 import { Ordering, and, equal, isEq } from "../ordering.js";
 
 import type { Contravariant } from "./variance.js";
 import type { Monoid } from "./monoid.js";
+import type { PartialEq } from "./partial-eq.js";
 
 declare const partialOrdNominal: unique symbol;
 export type PartialOrdHktKey = typeof partialOrdNominal;

--- a/src/type-class/ord.ts
+++ b/src/type-class/ord.ts
@@ -1,4 +1,5 @@
 import { Eq, eqSymbol } from "./eq.js";
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
 import { Ordering, isEq } from "../ordering.js";
 
 import type { PartialOrd } from "./partial-ord.js";
@@ -20,6 +21,29 @@ export const fromCmp = <Lhs, Rhs>(cmp: (lhs: Lhs, rhs: Rhs) => Ordering): Ord<Lh
     cmp,
     [eqSymbol]: true,
 });
+
+export function fromProjection<F>(
+    projection: <X>(structure: GetHktA1<F, X>) => X,
+): <T>(order: Ord<T>) => Ord<GetHktA1<F, T>>;
+export function fromProjection<F, A>(
+    projection: <X>(structure: GetHktA2<F, A, X>) => X,
+): <T>(order: Ord<T>) => Ord<GetHktA2<F, A, T>>;
+export function fromProjection<F, B, A>(
+    projection: <X>(structure: GetHktA3<F, B, A, X>) => X,
+): <T>(order: Ord<T>) => Ord<GetHktA3<F, B, A, T>>;
+export function fromProjection<F, C, B, A>(
+    projection: <X>(structure: GetHktA4<F, C, B, A, X>) => X,
+): <T>(order: Ord<T>) => Ord<GetHktA4<F, C, B, A, T>>;
+export function fromProjection<F extends symbol>(
+    projection: <X>(structure: Hkt<F, X>) => X,
+): <T>(order: Ord<T>) => Ord<Hkt<F, T>> {
+    return (order) => ({
+        eq: (l, r) => order.eq(projection(l), projection(r)),
+        [eqSymbol]: true,
+        partialCmp: (l, r) => order.partialCmp(projection(l), projection(r)),
+        cmp: (l, r) => order.cmp(projection(l), projection(r)),
+    });
+}
 
 export const reversed = <Lhs, Rhs>(ord: Ord<Lhs, Rhs>): Ord<Lhs, Rhs> => ({
     ...ord,

--- a/src/type-class/ord.ts
+++ b/src/type-class/ord.ts
@@ -1,57 +1,13 @@
 import { Eq, eqSymbol } from "./eq.js";
-import { Option, flatMap, map, mapOr, some } from "../option.js";
-import { Ordering, and, equal, isEq } from "../ordering.js";
+import { Ordering, isEq } from "../ordering.js";
 
-import type { Contravariant } from "./variance.js";
-import type { Monoid } from "./monoid.js";
-import type { PartialEq } from "./partial-eq.js";
-
-declare const partialOrdNominal: unique symbol;
-export type PartialOrdHktKey = typeof partialOrdNominal;
+import type { PartialOrd } from "./partial-ord.js";
+import { some } from "../option.js";
 
 /**
- * All instances of `PartialOrd` must satisfy following conditions:
- * - Transitivity: If `f` is `PartialOrd`, for all `a`, `b` and `c`; `f(a, b) == f(b, c) == f(a, c)`.
- * - Duality: If `f` is `PartialOrd`, for all `a` and `b`; `f(a, b) == -f(b, a)`.
- */
-export interface PartialOrd<Lhs, Rhs = Lhs> extends PartialEq<Lhs, Rhs> {
-    readonly partialCmp: (lhs: Lhs, rhs: Rhs) => Option<Ordering>;
-}
-
-export const fromPartialCmp = <Lhs, Rhs>(
-    partialCmp: (lhs: Lhs, rhs: Rhs) => Option<Ordering>,
-): PartialOrd<Lhs, Rhs> => ({
-    partialCmp,
-    eq: (l, r) => mapOr(false)((order: Ordering) => isEq(order))(partialCmp(l, r)),
-});
-
-declare module "../hkt.js" {
-    interface HktDictA1<A1> {
-        [partialOrdNominal]: PartialOrd<A1>;
-    }
-}
-
-export const contravariant: Contravariant<PartialOrdHktKey> = {
-    contraMap: (f) => (ord) => fromPartialCmp((l, r) => ord.partialCmp(f(l), f(r))),
-};
-
-export const identity: PartialOrd<unknown> = fromPartialCmp(() => some(equal));
-
-export const monoid = <Lhs, Rhs>(): Monoid<PartialOrd<Lhs, Rhs>> => ({
-    combine: (x, y) => ({
-        partialCmp: (l, r) =>
-            flatMap((first: Ordering) =>
-                map((second: Ordering) => and(second)(first))(y.partialCmp(l, r)),
-            )(x.partialCmp(l, r)),
-        eq: (l, r) => x.eq(l, r) && y.eq(l, r),
-    }),
-    identity,
-});
-
-/**
- * All instances of `PartialOrd` must satisfy following conditions:
- * - Transitivity: If `f` is `PartialOrd`, for all `a`, `b` and `c`; `f(a, b) == f(b, c) == f(a, c)`.
- * - Duality: If `f` is `PartialOrd`, for all `a` and `b`; `f(a, b) == -f(b, a)`.
+ * All instances of `Ord` must satisfy following conditions:
+ * - Transitivity: If `f` is `Ord`, for all `a`, `b` and `c`; `f(a, b) == f(b, c) == f(a, c)`.
+ * - Duality: If `f` is `Ord`, for all `a` and `b`; `f(a, b) == -f(b, a)`.
  * - Strict: Ordering for all values is well-defined (so the return value is not an `Option`).
  */
 export interface Ord<Lhs, Rhs = Lhs> extends PartialOrd<Lhs, Rhs>, Eq<Lhs, Rhs> {

--- a/src/type-class/ord.ts
+++ b/src/type-class/ord.ts
@@ -15,12 +15,14 @@ export interface Ord<Lhs, Rhs = Lhs> extends PartialOrd<Lhs, Rhs>, Eq<Lhs, Rhs> 
     readonly cmp: (lhs: Lhs, rhs: Rhs) => Ordering;
 }
 
-export const fromCmp = <Lhs, Rhs>(cmp: (lhs: Lhs, rhs: Rhs) => Ordering): Ord<Lhs, Rhs> => ({
-    eq: (l, r) => isEq(cmp(l, r)),
-    partialCmp: (l, r) => some(cmp(l, r)),
-    cmp,
-    [eqSymbol]: true,
-});
+export const fromCmp =
+    <Lhs, Rhs, X = void>(cmp: (x: X) => (lhs: Lhs, rhs: Rhs) => Ordering) =>
+    (x: X): Ord<Lhs, Rhs> => ({
+        eq: (l, r) => isEq(cmp(x)(l, r)),
+        partialCmp: (l, r) => some(cmp(x)(l, r)),
+        cmp: cmp(x),
+        [eqSymbol]: true,
+    });
 
 export function fromProjection<F>(
     projection: <X>(structure: GetHktA1<F, X>) => X,

--- a/src/type-class/ord.ts
+++ b/src/type-class/ord.ts
@@ -1,5 +1,5 @@
 import { Eq, eqSymbol } from "./eq.js";
-import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "../hkt.js";
 import { Ordering, isEq } from "../ordering.js";
 
 import type { PartialOrd } from "./partial-ord.js";

--- a/src/type-class/partial-eq.ts
+++ b/src/type-class/partial-eq.ts
@@ -1,3 +1,5 @@
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
+
 import type { Contravariant } from "./variance.js";
 import type { Monoid } from "./monoid.js";
 
@@ -30,6 +32,26 @@ export const fromPartialEquality = <Lhs, Rhs>(
 ): PartialEq<Lhs, Rhs> => ({
     eq: partialEquality,
 });
+
+export function fromProjection<F>(
+    projection: <X>(structure: GetHktA1<F, X>) => X,
+): <T>(equality: PartialEq<T>) => PartialEq<GetHktA1<F, T>>;
+export function fromProjection<F, A>(
+    projection: <X>(structure: GetHktA2<F, A, X>) => X,
+): <T>(equality: PartialEq<T>) => PartialEq<GetHktA2<F, A, T>>;
+export function fromProjection<F, B, A>(
+    projection: <X>(structure: GetHktA3<F, B, A, X>) => X,
+): <T>(equality: PartialEq<T>) => PartialEq<GetHktA3<F, B, A, T>>;
+export function fromProjection<F, C, B, A>(
+    projection: <X>(structure: GetHktA4<F, C, B, A, X>) => X,
+): <T>(equality: PartialEq<T>) => PartialEq<GetHktA4<F, C, B, A, T>>;
+export function fromProjection<F extends symbol>(
+    projection: <X>(structure: Hkt<F, X>) => X,
+): <T>(equality: PartialEq<T>) => PartialEq<Hkt<F, T>> {
+    return (equality) => ({
+        eq: (l, r) => equality.eq(projection(l), projection(r)),
+    });
+}
 
 export const strict = <T>() => fromPartialEquality<T, T>((l, r) => l === r);
 

--- a/src/type-class/partial-eq.ts
+++ b/src/type-class/partial-eq.ts
@@ -27,11 +27,11 @@ export const contravariant: Contravariant<PartialEqHktKey> = {
         (p: PartialEq<T2>): PartialEq<T1> => ({ eq: (l, r) => p.eq(f(l), f(r)) }),
 };
 
-export const fromPartialEquality = <Lhs, Rhs>(
-    partialEquality: (l: Lhs, r: Rhs) => boolean,
-): PartialEq<Lhs, Rhs> => ({
-    eq: partialEquality,
-});
+export const fromPartialEquality =
+    <Lhs, Rhs, X = void>(partialEquality: (x: X) => (l: Lhs, r: Rhs) => boolean) =>
+    (x: X): PartialEq<Lhs, Rhs> => ({
+        eq: partialEquality(x),
+    });
 
 export function fromProjection<F>(
     projection: <X>(structure: GetHktA1<F, X>) => X,
@@ -53,9 +53,9 @@ export function fromProjection<F extends symbol>(
     });
 }
 
-export const strict = <T>() => fromPartialEquality<T, T>((l, r) => l === r);
+export const strict = <T>() => fromPartialEquality<T, T>(() => (l, r) => l === r)();
 
-export const identity = fromPartialEquality(() => true);
+export const identity = fromPartialEquality(() => () => true)();
 
 export const monoid = <Lhs, Rhs>(): Monoid<PartialEq<Lhs, Rhs>> => ({
     combine: (x, y) => ({ eq: (l, r) => x.eq(l, r) && y.eq(l, r) }),

--- a/src/type-class/partial-eq.ts
+++ b/src/type-class/partial-eq.ts
@@ -1,0 +1,41 @@
+import type { Contravariant } from "./variance.js";
+import type { Monoid } from "./monoid.js";
+
+/**
+ * All instances of `PartialEq` must satisfy the following conditions:
+ * - Symmetric: `PartialEq<A, B>` always equals to `PartialEq<B, A>`.
+ * - Transitive: `PartialEq<A, B>` and `PartialEq<B, C>` always implies `PartialEq<A, C>`.
+ */
+
+export interface PartialEq<Lhs, Rhs = Lhs> {
+    readonly eq: (l: Lhs, r: Rhs) => boolean;
+}
+
+declare const partialEqNominal: unique symbol;
+export type PartialEqHktKey = typeof partialEqNominal;
+declare module "../hkt.js" {
+    interface HktDictA1<A1> {
+        [partialEqNominal]: PartialEq<A1>;
+    }
+}
+
+export const contravariant: Contravariant<PartialEqHktKey> = {
+    contraMap:
+        <T1, T2>(f: (arg: T1) => T2) =>
+        (p: PartialEq<T2>): PartialEq<T1> => ({ eq: (l, r) => p.eq(f(l), f(r)) }),
+};
+
+export const fromPartialEquality = <Lhs, Rhs>(
+    partialEquality: (l: Lhs, r: Rhs) => boolean,
+): PartialEq<Lhs, Rhs> => ({
+    eq: partialEquality,
+});
+
+export const strict = <T>() => fromPartialEquality<T, T>((l, r) => l === r);
+
+export const identity = fromPartialEquality(() => true);
+
+export const monoid = <Lhs, Rhs>(): Monoid<PartialEq<Lhs, Rhs>> => ({
+    combine: (x, y) => ({ eq: (l, r) => x.eq(l, r) && y.eq(l, r) }),
+    identity,
+});

--- a/src/type-class/partial-eq.ts
+++ b/src/type-class/partial-eq.ts
@@ -1,4 +1,4 @@
-import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "../hkt.js";
 
 import type { Contravariant } from "./variance.js";
 import type { Monoid } from "./monoid.js";

--- a/src/type-class/partial-ord.ts
+++ b/src/type-class/partial-ord.ts
@@ -1,4 +1,4 @@
-import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "../hkt.js";
 import { Option, flatMap, map, mapOr, some } from "../option.js";
 import { Ordering, and, equal, isEq } from "../ordering.js";
 

--- a/src/type-class/partial-ord.ts
+++ b/src/type-class/partial-ord.ts
@@ -1,3 +1,4 @@
+import type { GetHktA1, GetHktA2, GetHktA3, GetHktA4, Hkt } from "src/hkt.js";
 import { Option, flatMap, map, mapOr, some } from "../option.js";
 import { Ordering, and, equal, isEq } from "../ordering.js";
 
@@ -23,6 +24,27 @@ export const fromPartialCmp = <Lhs, Rhs>(
     partialCmp,
     eq: (l, r) => mapOr(false)((order: Ordering) => isEq(order))(partialCmp(l, r)),
 });
+
+export function fromProjection<F>(
+    projection: <X>(structure: GetHktA1<F, X>) => X,
+): <T>(order: PartialOrd<T>) => PartialOrd<GetHktA1<F, T>>;
+export function fromProjection<F, A>(
+    projection: <X>(structure: GetHktA2<F, A, X>) => X,
+): <T>(order: PartialOrd<T>) => PartialOrd<GetHktA2<F, A, T>>;
+export function fromProjection<F, B, A>(
+    projection: <X>(structure: GetHktA3<F, B, A, X>) => X,
+): <T>(order: PartialOrd<T>) => PartialOrd<GetHktA3<F, B, A, T>>;
+export function fromProjection<F, C, B, A>(
+    projection: <X>(structure: GetHktA4<F, C, B, A, X>) => X,
+): <T>(order: PartialOrd<T>) => PartialOrd<GetHktA4<F, C, B, A, T>>;
+export function fromProjection<F extends symbol>(
+    projection: <X>(structure: Hkt<F, X>) => X,
+): <T>(order: PartialOrd<T>) => PartialOrd<Hkt<F, T>> {
+    return (order) => ({
+        eq: (l, r) => order.eq(projection(l), projection(r)),
+        partialCmp: (l, r) => order.partialCmp(projection(l), projection(r)),
+    });
+}
 
 declare module "../hkt.js" {
     interface HktDictA1<A1> {

--- a/src/type-class/partial-ord.ts
+++ b/src/type-class/partial-ord.ts
@@ -1,0 +1,48 @@
+import { Option, flatMap, map, mapOr, some } from "../option.js";
+import { Ordering, and, equal, isEq } from "../ordering.js";
+
+import type { Contravariant } from "./variance.js";
+import type { Monoid } from "./monoid.js";
+import type { PartialEq } from "./partial-eq.js";
+
+declare const partialOrdNominal: unique symbol;
+export type PartialOrdHktKey = typeof partialOrdNominal;
+/**
+ * All instances of `PartialOrd` must satisfy following conditions:
+ * - Transitivity: If `f` is `PartialOrd`, for all `a`, `b` and `c`; `f(a, b) == f(b, c) == f(a, c)`.
+ * - Duality: If `f` is `PartialOrd`, for all `a` and `b`; `f(a, b) == -f(b, a)`.
+ */
+
+export interface PartialOrd<Lhs, Rhs = Lhs> extends PartialEq<Lhs, Rhs> {
+    readonly partialCmp: (lhs: Lhs, rhs: Rhs) => Option<Ordering>;
+}
+
+export const fromPartialCmp = <Lhs, Rhs>(
+    partialCmp: (lhs: Lhs, rhs: Rhs) => Option<Ordering>,
+): PartialOrd<Lhs, Rhs> => ({
+    partialCmp,
+    eq: (l, r) => mapOr(false)((order: Ordering) => isEq(order))(partialCmp(l, r)),
+});
+
+declare module "../hkt.js" {
+    interface HktDictA1<A1> {
+        [partialOrdNominal]: PartialOrd<A1>;
+    }
+}
+
+export const contravariant: Contravariant<PartialOrdHktKey> = {
+    contraMap: (f) => (ord) => fromPartialCmp((l, r) => ord.partialCmp(f(l), f(r))),
+};
+
+export const identity: PartialOrd<unknown> = fromPartialCmp(() => some(equal));
+
+export const monoid = <Lhs, Rhs>(): Monoid<PartialOrd<Lhs, Rhs>> => ({
+    combine: (x, y) => ({
+        partialCmp: (l, r) =>
+            flatMap((first: Ordering) =>
+                map((second: Ordering) => and(second)(first))(y.partialCmp(l, r)),
+            )(x.partialCmp(l, r)),
+        eq: (l, r) => x.eq(l, r) && y.eq(l, r),
+    }),
+    identity,
+});

--- a/src/zipper.ts
+++ b/src/zipper.ts
@@ -15,11 +15,12 @@ import {
     unCons,
 } from "./list.js";
 import { Option, andThen, isNone, map as optionMap, unwrap } from "./option.js";
-import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Comonad1 } from "./type-class/comonad.js";
 import type { Functor1 } from "./type-class/functor.js";
+import type { Ord } from "./type-class/ord.js";
 import type { PartialEq } from "./type-class/partial-eq.js";
+import type { PartialOrd } from "./type-class/partial-ord.js";
 import { andThen as thenWith } from "./ordering.js";
 
 declare const zipperNominal: unique symbol;

--- a/src/zipper.ts
+++ b/src/zipper.ts
@@ -1,4 +1,4 @@
-import { Eq, PartialEq, eqSymbol } from "./type-class/eq.js";
+import { Eq, eqSymbol } from "./type-class/eq.js";
 import {
     List,
     appendToHead,
@@ -19,6 +19,7 @@ import type { Ord, PartialOrd } from "./type-class/ord.js";
 
 import type { Comonad1 } from "./type-class/comonad.js";
 import type { Functor1 } from "./type-class/functor.js";
+import type { PartialEq } from "./type-class/partial-eq.js";
 import { andThen as thenWith } from "./ordering.js";
 
 declare const zipperNominal: unique symbol;


### PR DESCRIPTION
- fix!: Tidy up exports of eq and order
- Impl Ord for Frozen
- Impl PartialOrd for Number
- Impl Ord for String
- Add TupleN
- Impl Eq for Boolean
- Split PartialEq into another file
- Add fromProjection
- Split PartialOrd into another file
- Add fromProjection for PartialOrd and Ord
- Enforce converter
- Fix bool equality
- Use projection for Cat
- Use converter for Cofree
- Use converter for Free
- Use converter for Frozen
- Use projection for Lazy
- Use converter for Tuple
- Use converter for List
- Use converter for Option
- Use converter for Result
- Fix string cmp
- Fix TupleN cmp
- Use converter for Zipper
- Fix number cmp
- Make import path relative
- Sort imports
