### PR TITLE
feat: Add PartialEqUnary implementations

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -25,15 +25,16 @@ import type { Reduce } from "./type-class/reduce.ts";
 import type { Traversable } from "./type-class/traversable.ts";
 
 export const partialEquality =
-    <T>(equality: PartialEq<T>) =>
-    (l: readonly T[], r: readonly T[]): boolean =>
+    <L, R = L>(equality: PartialEq<L, R>) =>
+    (l: readonly L[], r: readonly R[]): boolean =>
         l.length === r.length &&
         l.every((left, i) => equality.eq(left, r[i]));
-export const partialEq: <T>(equality: PartialEq<T>) => PartialEq<T[]> =
-    fromPartialEquality(partialEquality);
+export const partialEq: <L, R>(
+    equality: PartialEq<L, R>,
+) => PartialEq<L[], R[]> = fromPartialEquality(partialEquality);
 export const partialCmp =
-    <T>(order: PartialOrd<T>) =>
-    (l: readonly T[], r: readonly T[]): Option<Ordering> =>
+    <L, R = L>(order: PartialOrd<L, R>) =>
+    (l: readonly L[], r: readonly R[]): Option<Ordering> =>
         foldR((
             next: Option<Ordering>,
         ): (acc: Option<Ordering>) => Option<Ordering> =>
@@ -44,10 +45,13 @@ export const partialCmp =
 export const partialOrd: <T>(order: PartialOrd<T>) => PartialOrd<T[]> =
     fromPartialCmp(partialCmp);
 export const equality =
-    <T>(equality: Eq<T>) => (l: readonly T[], r: readonly T[]): boolean =>
+    <L, R = L>(equality: Eq<L, R>) =>
+    (l: readonly L[], r: readonly R[]): boolean =>
         l.length === r.length &&
         l.every((left, i) => equality.eq(left, r[i]));
-export const eq: <T>(equality: Eq<T>) => Eq<T[]> = fromEquality(equality);
+export const eq: <L, R = L>(equality: Eq<L, R>) => Eq<L[], R[]> = fromEquality(
+    equality,
+);
 export const cmp =
     <T>(order: Ord<T>) => (l: readonly T[], r: readonly T[]): Ordering =>
         foldR(and)(Math.sign(l.length - r.length) as Ordering)(

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -10,6 +10,7 @@ import { type Applicative, liftA2 } from "./type-class/applicative.ts";
 import { collect, type Distributive } from "./type-class/distributive.ts";
 import type { Foldable } from "./type-class/foldable.ts";
 import type { Functor } from "./type-class/functor.ts";
+import type { PartialEqUnary } from "./type-class/partial-eq.ts";
 import type { Traversable } from "./type-class/traversable.ts";
 
 /**
@@ -20,6 +21,13 @@ export type Compose<F, G, T> = Get1<F, Get1<G, T>>;
 export interface ComposeHkt extends Hkt3 {
     readonly type: Compose<this["arg3"], this["arg2"], this["arg1"]>;
 }
+
+export const partialEqUnary = <F, G>(
+    eqUnaryF: PartialEqUnary<F>,
+    eqUnaryG: PartialEqUnary<G>,
+): PartialEqUnary<Apply2Only<Apply3Only<ComposeHkt, F>, G>> => ({
+    liftEq: (equality) => eqUnaryF.liftEq(eqUnaryG.liftEq(equality)),
+});
 
 export const newCompose = <F, G, T>(
     fgt: Get1<F, Get1<G, T>>,

--- a/src/const.ts
+++ b/src/const.ts
@@ -6,7 +6,7 @@ import type { Foldable } from "./type-class/foldable.ts";
 import type { Functor } from "./type-class/functor.ts";
 import type { Monoid } from "./type-class/monoid.ts";
 import type { Ord } from "./type-class/ord.ts";
-import type { PartialEq } from "./type-class/partial-eq.ts";
+import type { PartialEq, PartialEqUnary } from "./type-class/partial-eq.ts";
 import type { PartialOrd } from "./type-class/partial-ord.ts";
 import type { SemiGroupoid } from "./type-class/semi-groupoid.ts";
 
@@ -38,6 +38,13 @@ export const ord = <A, B>(order: Ord<A>): Ord<Const<A, B>> => ({
     ...partialOrd(order),
     cmp: (l, r) => order.cmp(l.getConst, r.getConst),
     [eqSymbol]: true,
+});
+
+export const partialEqUnary = <A>(
+    equality: PartialEq<A>,
+): PartialEqUnary<Apply2Only<ConstHkt, A>> => ({
+    liftEq: <L, R>() => (l: Const<A, L>, r: Const<A, R>): boolean =>
+        equality.eq(l.getConst, r.getConst),
 });
 
 export const compose =

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -5,6 +5,7 @@ import type { Comonad } from "./type-class/comonad.ts";
 import type { Distributive } from "./type-class/distributive.ts";
 import type { Functor } from "./type-class/functor.ts";
 import type { Monad } from "./type-class/monad.ts";
+import type { PartialEqUnary } from "./type-class/partial-eq.ts";
 import type { Settable } from "./type-class/settable.ts";
 import type { Traversable } from "./type-class/traversable.ts";
 
@@ -85,3 +86,8 @@ export const settable: Settable<IdentityHkt> = {
     ...distributive,
     untainted: id,
 };
+
+/**
+ * The `PartialEqUnary` instance for `Identity`.
+ */
+export const partialEqUnary: PartialEqUnary<IdentityHkt> = { liftEq: id };

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -14,6 +14,7 @@ import {
 import {
     fromProjection as partialEqFromProjection,
     type PartialEq,
+    type PartialEqUnary,
 } from "./type-class/partial-eq.ts";
 import {
     fromProjection as partialOrdFromProjection,
@@ -96,16 +97,22 @@ export const force = <L>(lazy: Lazy<L>): L => {
     return evaluated;
 };
 
-export const partialEq: <T>(equality: PartialEq<T>) => PartialEq<Lazy<T>> =
-    partialEqFromProjection<LazyHkt>(force);
-export const eq: <T>(equality: Eq<T>) => Eq<Lazy<T>> = eqFromProjection<
-    LazyHkt
->(force);
+export const partialEq: <L, R>(
+    equality: PartialEq<L, R>,
+) => PartialEq<Lazy<L>, Lazy<R>> = partialEqFromProjection<LazyHkt>(force);
+export const eq: <L, R>(equality: Eq<L, R>) => Eq<Lazy<L>, Lazy<R>> =
+    eqFromProjection<LazyHkt>(force);
 export const partialOrd: <T>(equality: PartialOrd<T>) => PartialOrd<Lazy<T>> =
     partialOrdFromProjection<LazyHkt>(force);
 export const ord: <T>(equality: Ord<T>) => Ord<Lazy<T>> = ordFromProjection<
     LazyHkt
 >(force);
+
+export const partialEqUnary: PartialEqUnary<LazyHkt> = {
+    liftEq:
+        <L, R>(equality: (l: L, r: R) => boolean) =>
+        (l: Lazy<L>, r: Lazy<R>): boolean => equality(force(l), force(r)),
+};
 
 /**
  * Wraps the evaluated value as a `Lazy`.

--- a/src/map.ts
+++ b/src/map.ts
@@ -27,13 +27,15 @@ import { fromCmp, type Ord } from "./type-class/ord.ts";
 import {
     fromPartialEquality,
     type PartialEq,
+    type PartialEqUnary,
 } from "./type-class/partial-eq.ts";
 import { fromPartialCmp, type PartialOrd } from "./type-class/partial-ord.ts";
 import { semiGroupSymbol } from "./type-class/semi-group.ts";
 import type { Traversable } from "./type-class/traversable.ts";
 
 export const eq =
-    <K, V>(equality: PartialEq<V>) => (l: Map<K, V>, r: Map<K, V>): boolean => {
+    <K, L, R = L>(equality: PartialEq<L, R>) =>
+    (l: Map<K, L>, r: Map<K, R>): boolean => {
         if (l.size !== r.size) {
             return false;
         }
@@ -73,12 +75,12 @@ export const cmp = <K, V>(ord: {
     )(sortedL, sortedR);
 };
 
-export const partialEquality: <K, V>(
-    equality: PartialEq<V>,
-) => PartialEq<Map<K, V>> = fromPartialEquality(eq);
-export const equality: <K, V>(
-    equality: Eq<V>,
-) => Eq<Map<K, V>> = fromEquality(eq);
+export const partialEquality: <K, L, R = L>(
+    equality: PartialEq<L, R>,
+) => PartialEq<Map<K, L>, Map<K, R>> = fromPartialEquality(eq);
+export const equality: <K, L, R = L>(
+    equality: Eq<L, R>,
+) => Eq<Map<K, L>, Map<K, R>> = fromEquality(eq);
 export const partialOrd: <K, V>(ord: {
     ordK: Ord<K>;
     ordV: Ord<V>;
@@ -87,6 +89,16 @@ export const ord: <K, V>(ord: {
     ordK: Ord<K>;
     ordV: Ord<V>;
 }) => Ord<Map<K, V>> = fromCmp(cmp);
+
+/**
+ * The `PartialEqUnary` instance for `Map<K, _>`.
+ */
+export const partialEqUnary = <K>(): PartialEqUnary<Apply2Only<MapHkt, K>> => ({
+    liftEq:
+        <L, R = L>(equality: (l: L, r: R) => boolean) =>
+        (l: Map<K, L>, r: Map<K, R>): boolean =>
+            eq<K, L, R>({ eq: equality })(l, r),
+});
 
 export const isEmpty = <K, V>(m: Map<K, V>): boolean => m.size === 0;
 export const size = <K, V>(m: Map<K, V>): number => m.size;

--- a/src/option.ts
+++ b/src/option.ts
@@ -38,6 +38,7 @@ import { fromCmp, type Ord } from "./type-class/ord.ts";
 import {
     fromPartialEquality,
     type PartialEq,
+    type PartialEqUnary,
 } from "./type-class/partial-eq.ts";
 import { fromPartialCmp, type PartialOrd } from "./type-class/partial-ord.ts";
 import { semiGroupSymbol } from "./type-class/semi-group.ts";
@@ -171,19 +172,22 @@ export const toArray = <T>(opt: Option<T>): T[] => {
 };
 
 export const partialEquality =
-    <T>(equalityT: PartialEq<T>) =>
-    (optA: Option<T>, optB: Option<T>): boolean =>
+    <L, R = L>(equalityT: PartialEq<L, R>) =>
+    (optA: Option<L>, optB: Option<R>): boolean =>
         (isNone(optA) && isNone(optB)) ||
         (isSome(optA) && isSome(optB) && equalityT.eq(optA[1], optB[1]));
-export const partialEq: <T>(equalityT: PartialEq<T>) => PartialEq<Option<T>> =
-    fromPartialEquality(partialEquality);
+export const partialEq: <L, R = L>(
+    equalityT: PartialEq<L, R>,
+) => PartialEq<Option<L>, Option<R>> = fromPartialEquality(partialEquality);
 export const equality =
-    <T>(equalityT: Eq<T>) => (optA: Option<T>, optB: Option<T>): boolean =>
+    <L, R = L>(equalityT: Eq<L, R>) =>
+    (optA: Option<L>, optB: Option<R>): boolean =>
         (isNone(optA) && isNone(optB)) ||
         (isSome(optA) && isSome(optB) && equalityT.eq(optA[1], optB[1]));
-export const eq: <T>(equalityT: Eq<T>) => Eq<Option<T>> = fromEquality(
-    equality,
-);
+export const eq: <L, R = L>(equalityT: Eq<L, R>) => Eq<Option<L>, Option<R>> =
+    fromEquality(
+        equality,
+    );
 export const partialCmp =
     <T>(order: PartialOrd<T>) =>
     (l: Option<T>, r: Option<T>): Option<Ordering> => {
@@ -219,6 +223,10 @@ export const cmp =
 export const ord: <T>(order: Ord<T>) => Ord<Option<T>> = <T>(
     order: Ord<T, T>,
 ) => fromCmp(cmp)(order);
+
+export const partialEqUnary: PartialEqUnary<OptionHkt> = {
+    liftEq: (equality) => partialEquality({ eq: equality }),
+};
 
 /**
  * Flattens the nested optional.

--- a/src/range-q.ts
+++ b/src/range-q.ts
@@ -34,7 +34,7 @@ export const fromIterable =
         acc: [...iterable].reduce<[T[], T]>(
             (prev, curr) => {
                 const next = group.combine(prev[1], curr);
-                return [[...prev[0], next], next];
+                return [[...prev[0], next], next] as [T[], T];
             },
             [[], group.identity],
         )[0],

--- a/src/record.ts
+++ b/src/record.ts
@@ -23,6 +23,7 @@ import { fromCmp, type Ord } from "./type-class/ord.ts";
 import {
     fromPartialEquality,
     type PartialEq,
+    type PartialEqUnary,
 } from "./type-class/partial-eq.ts";
 import { fromPartialCmp, type PartialOrd } from "./type-class/partial-ord.ts";
 import { semiGroupSymbol } from "./type-class/semi-group.ts";
@@ -47,8 +48,8 @@ import { foldR as foldRArray } from "./array.ts";
 import { doT } from "./cat.ts";
 
 export const eq =
-    <K extends string, V>(equality: PartialEq<V>) =>
-    (l: Record<K, V>, r: Record<K, V>): boolean => {
+    <K extends string, L, R = L>(equality: PartialEq<L, R>) =>
+    (l: Record<K, L>, r: Record<K, R>): boolean => {
         for (const leftKey of (Object.keys(l) as (keyof typeof l)[])) {
             const leftValue = l[leftKey];
             const rightValue = r[leftKey];
@@ -84,18 +85,27 @@ export const cmp = <K extends string, V>(
     )(sortedL, sortedR);
 };
 
-export const partialEquality: <K extends string, V>(
-    equality: PartialEq<V>,
-) => PartialEq<Record<K, V>> = fromPartialEquality(eq);
-export const equality: <K extends string, V>(
-    equality: Eq<V>,
-) => Eq<Record<K, V>> = fromEquality(eq);
+export const partialEquality: <K extends string, L, R = L>(
+    equality: PartialEq<L, R>,
+) => PartialEq<Record<K, L>, Record<K, R>> = fromPartialEquality(eq);
+export const equality: <K extends string, L, R = L>(
+    equality: Eq<L, R>,
+) => Eq<Record<K, L>, Record<K, R>> = fromEquality(eq);
 export const partialOrd: <K extends string, V>(
     ordV: Ord<V>,
 ) => PartialOrd<Record<K, V>> = fromPartialCmp(partialCmp);
 export const ord: <K extends string, V>(
     ordV: Ord<V>,
 ) => Ord<Record<K, V>> = fromCmp(cmp);
+
+/**
+ * The `PartialEqUnary` instance for `Record<K, _>`.
+ */
+export const partialEqUnary = <K>(): PartialEqUnary<
+    Apply2Only<RecordHkt, K>
+> => ({
+    liftEq: (equality) => eq({ eq: equality }),
+});
 
 export const isEmpty = <K extends string, V>(m: Record<K, V>): boolean =>
     Object.keys(m).length === 0;

--- a/src/these.ts
+++ b/src/these.ts
@@ -20,7 +20,7 @@ import { type Eq, eqSymbol } from "./type-class/eq.ts";
 import type { Foldable } from "./type-class/foldable.ts";
 import type { Functor } from "./type-class/functor.ts";
 import type { Monad } from "./type-class/monad.ts";
-import type { PartialEq } from "./type-class/partial-eq.ts";
+import type { PartialEq, PartialEqUnary } from "./type-class/partial-eq.ts";
 import { type SemiGroup, semiGroupSymbol } from "./type-class/semi-group.ts";
 
 const thisSymbol = Symbol("TheseThis");
@@ -102,10 +102,10 @@ export interface TheseHkt extends Hkt2 {
     readonly type: These<this["arg2"], this["arg1"]>;
 }
 
-export const partialEq = <A, B>(
+export const partialEq = <A, L, R = L>(
     equalityA: PartialEq<A>,
-    equalityB: PartialEq<B>,
-): PartialEq<These<A, B>> => ({
+    equalityB: PartialEq<L, R>,
+): PartialEq<These<A, L>, These<A, R>> => ({
     eq: (l, r) => {
         if (isThis(l) && isThis(r)) {
             return equalityA.eq(l[1], r[1]);
@@ -119,12 +119,21 @@ export const partialEq = <A, B>(
         return false;
     },
 });
-export const eq = <A, B>(
+export const eq = <A, L, R = L>(
     equalityA: Eq<A>,
-    equalityB: Eq<B>,
-): Eq<These<A, B>> => ({
+    equalityB: Eq<L, R>,
+): Eq<These<A, L>, These<A, R>> => ({
     ...partialEq(equalityA, equalityB),
     [eqSymbol]: true,
+});
+
+/**
+ * The `PartialEqUnary` instance for `These<A, _>`.
+ */
+export const partialEqUnary = <A>(
+    equalityA: PartialEq<A>,
+): PartialEqUnary<Apply2Only<TheseHkt, A>> => ({
+    liftEq: (equality) => partialEq(equalityA, { eq: equality }).eq,
 });
 
 /**

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -45,12 +45,11 @@ export const partialEq: <A, L, R = L>(
         equalityB: PartialEq<L, R>;
     },
 ) => PartialEq<Tuple<A, L>, Tuple<A, R>> = fromPartialEquality(partialEquality);
-export const equality =
-    <A, L, R = L>(
-        { equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<L, R> },
-    ) =>
-    (l: Tuple<A, L>, r: Tuple<A, R>): boolean =>
-        equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]);
+export const equality = <A, L, R = L>(
+    { equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<L, R> },
+) =>
+(l: Tuple<A, L>, r: Tuple<A, R>): boolean =>
+    equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]);
 export const eq: <A, L, R = L>(
     { equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<L, R> },
 ) => Eq<Tuple<A, L>, Tuple<A, R>> = fromEquality(equality);

--- a/src/tuple.ts
+++ b/src/tuple.ts
@@ -20,6 +20,7 @@ import { fromCmp, type Ord } from "./type-class/ord.ts";
 import {
     fromPartialEquality,
     type PartialEq,
+    type PartialEqUnary,
 } from "./type-class/partial-eq.ts";
 import { fromPartialCmp, type PartialOrd } from "./type-class/partial-ord.ts";
 import type { SemiGroup } from "./type-class/semi-group.ts";
@@ -30,27 +31,29 @@ import type { SemiGroupal } from "./type-class/semi-groupal.ts";
  */
 export type Tuple<A, B> = readonly [A, B];
 
-export const partialEquality = <A, B>(
+export const partialEquality = <A, L, R = L>(
     { equalityA, equalityB }: {
         equalityA: PartialEq<A>;
-        equalityB: PartialEq<B>;
+        equalityB: PartialEq<L, R>;
     },
 ) =>
-(l: Tuple<A, B>, r: Tuple<A, B>): boolean =>
+(l: Tuple<A, L>, r: Tuple<A, R>): boolean =>
     equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]);
-export const partialEq: <A, B>(
+export const partialEq: <A, L, R = L>(
     { equalityA, equalityB }: {
         equalityA: PartialEq<A>;
-        equalityB: PartialEq<B>;
+        equalityB: PartialEq<L, R>;
     },
-) => PartialEq<Tuple<A, B>> = fromPartialEquality(partialEquality);
+) => PartialEq<Tuple<A, L>, Tuple<A, R>> = fromPartialEquality(partialEquality);
 export const equality =
-    <A, B>({ equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<B> }) =>
-    (l: Tuple<A, B>, r: Tuple<A, B>): boolean =>
+    <A, L, R = L>(
+        { equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<L, R> },
+    ) =>
+    (l: Tuple<A, L>, r: Tuple<A, R>): boolean =>
         equalityA.eq(l[0], r[0]) && equalityB.eq(l[1], r[1]);
-export const eq: <A, B>(
-    { equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<B> },
-) => Eq<Tuple<A, B>> = fromEquality(equality);
+export const eq: <A, L, R = L>(
+    { equalityA, equalityB }: { equalityA: Eq<A>; equalityB: Eq<L, R> },
+) => Eq<Tuple<A, L>, Tuple<A, R>> = fromEquality(equality);
 export const partialCmp =
     <A, B>({ ordA, ordB }: { ordA: PartialOrd<A>; ordB: PartialOrd<B> }) =>
     ([a1, b1]: Tuple<A, B>, [a2, b2]: Tuple<A, B>): Option<Ordering> =>
@@ -65,6 +68,13 @@ export const cmp =
 export const ord: <A, B>(
     { ordA, ordB }: { ordA: Ord<A>; ordB: Ord<B> },
 ) => Ord<Tuple<A, B>> = fromCmp(cmp);
+
+export const partialEqUnary = <A>(
+    equalityA: PartialEq<A>,
+): PartialEqUnary<Apply2Only<TupleHkt, A>> => ({
+    liftEq: (equality) =>
+        partialEquality({ equalityA, equalityB: { eq: equality } }),
+});
 
 /**
  * Creates a new tuple from two provided values.

--- a/src/type-class/eq.ts
+++ b/src/type-class/eq.ts
@@ -37,7 +37,7 @@ export const fromEquality =
 
 export const fromProjection =
     <F>(projection: <X>(structure: Get1<F, X>) => X) =>
-    <T>(equality: Eq<T>): Eq<Get1<F, T>> => ({
+    <L, R>(equality: Eq<L, R>): Eq<Get1<F, L>, Get1<F, R>> => ({
         eq: (l, r) => equality.eq(projection(l), projection(r)),
         [eqSymbol]: true,
     });

--- a/src/type-class/partial-eq.ts
+++ b/src/type-class/partial-eq.ts
@@ -33,7 +33,7 @@ export const fromPartialEquality = <Lhs, Rhs, X = void>(
 
 export const fromProjection =
     <F>(projection: <X>(structure: Get1<F, X>) => X) =>
-    <T>(equality: PartialEq<T>): PartialEq<Get1<F, T>> => ({
+    <L, R>(equality: PartialEq<L, R>): PartialEq<Get1<F, L>, Get1<F, R>> => ({
         eq: (l, r) => equality.eq(projection(l), projection(r)),
     });
 

--- a/src/type-class/partial-eq.ts
+++ b/src/type-class/partial-eq.ts
@@ -24,7 +24,7 @@ export const contravariant: Contravariant<PartialEqHkt> = {
         }),
 };
 
-export const fromPartialEquality = <Lhs, Rhs, X = void>(
+export const fromPartialEquality = <Lhs, Rhs = Lhs, X = void>(
     partialEquality: (x: X) => (l: Lhs, r: Rhs) => boolean,
 ) =>
 (x: X): PartialEq<Lhs, Rhs> => ({
@@ -33,17 +33,19 @@ export const fromPartialEquality = <Lhs, Rhs, X = void>(
 
 export const fromProjection =
     <F>(projection: <X>(structure: Get1<F, X>) => X) =>
-    <L, R>(equality: PartialEq<L, R>): PartialEq<Get1<F, L>, Get1<F, R>> => ({
+    <L, R = L>(
+        equality: PartialEq<L, R>,
+    ): PartialEq<Get1<F, L>, Get1<F, R>> => ({
         eq: (l, r) => equality.eq(projection(l), projection(r)),
     });
 
 export const strict = <T>(): PartialEq<T> =>
     fromPartialEquality<T, T>(() => (l, r) => l === r)();
 
-export const identity: <Lhs, Rhs>() => PartialEq<Lhs, Rhs> =
+export const identity: <Lhs, Rhs = Lhs>() => PartialEq<Lhs, Rhs> =
     fromPartialEquality(() => () => true);
 
-export const monoid = <Lhs, Rhs>(): Monoid<PartialEq<Lhs, Rhs>> => ({
+export const monoid = <Lhs, Rhs = Lhs>(): Monoid<PartialEq<Lhs, Rhs>> => ({
     combine: (x, y) => ({ eq: (l, r) => x.eq(l, r) && y.eq(l, r) }),
     identity: identity(),
     [semiGroupSymbol]: true,
@@ -62,7 +64,7 @@ export interface PartialEqUnary<F> {
  * @returns The new `PartialEqUnary` for `F`.
  */
 export const fromLifter = <F>(
-    lifter: <Lhs, Rhs>(
+    lifter: <Lhs, Rhs = Lhs>(
         eq: PartialEq<Lhs, Rhs>,
     ) => PartialEq<Get1<F, Lhs>, Get1<F, Rhs>>,
 ): PartialEqUnary<F> => ({

--- a/src/yoneda.ts
+++ b/src/yoneda.ts
@@ -1,6 +1,7 @@
 import { compose, id } from "./func.ts";
 import type { Apply2Only, Get1, Hkt2 } from "./hkt.ts";
 import type { Functor } from "./type-class/functor.ts";
+import type { PartialEqUnary } from "./type-class/partial-eq.ts";
 
 /**
  * The yoneda functor, a partial application of `map` to its second argument.
@@ -8,6 +9,18 @@ import type { Functor } from "./type-class/functor.ts";
 export interface Yoneda<F, A> {
     readonly yoneda: <X>(fn: (a: A) => X) => Get1<F, X>;
 }
+
+/**
+ * The `PartialEqUnary` instance for `Yoneda<F, _>`.
+ */
+export const partialEqUnary = <F>(
+    eqUnary: PartialEqUnary<F>,
+): PartialEqUnary<YonedaHkt> => ({
+    liftEq:
+        <L, R = L>(equality: (l: L, r: R) => boolean) =>
+        (l: Yoneda<F, L>, r: Yoneda<F, R>): boolean =>
+            eqUnary.liftEq(equality)(l.yoneda(id), r.yoneda(id)),
+});
 
 /**
  * Lifts the value `a` into a partial application of `functor.map`. It is the natural isomorphism to `Yoneda<F, _>`.


### PR DESCRIPTION
- **Improve fromProjection type parameter**
- **Add partialEqUnary for Lazy**
- **Add partialEqUnary for Cofree**
- **Add partialEqUnary for Compose**
- **Add partialEqUnary for Const**
- **Improve default type parameter**
- **Add partialEq, eq and partialEqUnary for ControlFlow**
- **Add partialEqUnary for Free**
- **Add partialEqUnary for Identity**
- **Add partialEqUnary for Map**
- **Add partialEqUnary for Option**
- **Fix type error**
- **Add partialEqUnary for Record**
- **Add partialEqUnary for Result**
- **Add partialEqUnary for These**
- **Add partialEqUnary for Tuple**
- **Add partialEqUnary for Yoneda**
